### PR TITLE
redundant code that can cause errors when chaining loaders

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@ function isRequire(node) {
 }
 
 module.exports = function obfuscator(source) {
-  this.cacheable = true;
-
   // Parses source code and collects require expression nodes
   const entries = [];
 


### PR DESCRIPTION
raw-loader was throwing an error when using obfusctator beforehand