### PR TITLE
Updated javascript-obfuscator to 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obfuscator-loader",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A webpack loader for obfuscating single modules using javascript-obfuscator",
   "main": "lib/index.js",
   "directories": {
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/zakplus/obfuscator-loader#readme",
   "dependencies": {
     "esprima": "^4.0.0",
-    "javascript-obfuscator": "^0.15.0",
+    "javascript-obfuscator": "^0.24.0",
     "loader-utils": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Please update obfuscator-loader dependency and publish to npm.

It will solve the compatibility issue with node 13.5.0  https://github.com/javascript-obfuscator/javascript-obfuscator/issues/452

All seems working as expected with the latest obfuscator-loader, no migration required.

It will also solve the following issues
https://github.com/javascript-obfuscator/obfuscator-loader/issues/11
https://github.com/javascript-obfuscator/obfuscator-loader/issues/10
https://github.com/javascript-obfuscator/obfuscator-loader/issues/9